### PR TITLE
Improve forbidden zone constraints and add alignment rule validation

### DIFF
--- a/layout_solver.py
+++ b/layout_solver.py
@@ -266,14 +266,14 @@ def solve_layout(sheet_url, task_file_path):
                 )
                 continue
 
-            x_min_s = int(x_min * SCALE)
-            y_min_s = int(y_min * SCALE)
-            x_max_s = int(x_max * SCALE)
-            y_max_s = int(y_max * SCALE)
+            x_min_s = int(round(x_min * SCALE))
+            y_min_s = int(round(y_min * SCALE))
+            x_max_s = int(round(x_max * SCALE))
+            y_max_s = int(round(y_max * SCALE))
 
-            # Чтобы исключить касание границы, вводим минимальный отступ ZONE_MARGIN
-            # (1 мм при SCALE=1000)
-            ZONE_MARGIN = 1 # Отступ в одну масштабированную единицу (1 мм при SCALE=1000)
+            # Чтобы исключить даже касание границы, вводим минимальный отступ
+            # ZONE_MARGIN (1 мм при SCALE=1000)
+            ZONE_MARGIN = 1  # 1 масштабная единица = 1мм
 
             zone_safe = obj1_name.replace(' ', '_')
             print(
@@ -293,21 +293,17 @@ def solve_layout(sheet_url, task_file_path):
                 below = model.NewBoolVar(f"{iname}_below_{zone_safe}")
                 above = model.NewBoolVar(f"{iname}_above_{zone_safe}")
 
-                # Объект строго слева от зоны (без касания)
+                # Объект строго слева от зоны (с зазором)
                 model.Add(positions[iname]['x'] + width_s <= x_min_s - ZONE_MARGIN).OnlyEnforceIf(left)
-                model.Add(positions[iname]['x'] + width_s > x_min_s - ZONE_MARGIN).OnlyEnforceIf(left.Not())
 
-                # Объект строго справа от зоны (без касания)
+                # Объект строго справа от зоны (с зазором)
                 model.Add(positions[iname]['x'] >= x_max_s + ZONE_MARGIN).OnlyEnforceIf(right)
-                model.Add(positions[iname]['x'] < x_max_s + ZONE_MARGIN).OnlyEnforceIf(right.Not())
 
-                # Объект строго ниже зоны (без касания)
+                # Объект строго ниже зоны (с зазором)
                 model.Add(positions[iname]['y'] + depth_s <= y_min_s - ZONE_MARGIN).OnlyEnforceIf(below)
-                model.Add(positions[iname]['y'] + depth_s > y_min_s - ZONE_MARGIN).OnlyEnforceIf(below.Not())
 
-                # Объект строго выше зоны (без касания)
+                # Объект строго выше зоны (с зазором)
                 model.Add(positions[iname]['y'] >= y_max_s + ZONE_MARGIN).OnlyEnforceIf(above)
-                model.Add(positions[iname]['y'] < y_max_s + ZONE_MARGIN).OnlyEnforceIf(above.Not())
 
                 # хотя бы одно из условий должно выполниться
                 model.AddBoolOr([left, right, below, above])

--- a/validate_ifc.py
+++ b/validate_ifc.py
@@ -154,6 +154,22 @@ def validate_layout(rules_df, placements):
             distance = math.sqrt((center1_x - center2_x)**2 + (center1_y - center2_y)**2)
             check_passed = distance >= value
             actual_value_str = f"факт: {distance:.2f}м"
+        elif rule_type in ['Выровнять по оси X', 'Выровнять по оси Y']:
+            obj2_name = rule['Объект2']
+            if obj2_name not in placements:
+                print(f"  - [ПРЕДУПРЕЖДЕНИЕ] Объект '{obj2_name}' из правила не найден в IFC файле.")
+                continue
+
+            obj2 = placements[obj2_name]
+            center1_x, center1_y = obj1['x'] + obj1['width']/2, obj1['y'] + obj1['depth']/2
+            center2_x, center2_y = obj2['x'] + obj2['width']/2, obj2['y'] + obj2['depth']/2
+
+            if rule_type == 'Выровнять по оси X':
+                check_passed = math.isclose(center1_x, center2_x, abs_tol=0.001)
+                actual_value_str = f"центры: {center1_x:.3f}м и {center2_x:.3f}м"
+            else:
+                check_passed = math.isclose(center1_y, center2_y, abs_tol=0.001)
+                actual_value_str = f"центры: {center1_y:.3f}м и {center2_y:.3f}м"
         
         else:
             print(f"  - [НЕИЗВЕСТНО] Правило типа '{rule_type}' не поддерживается валидатором.")


### PR DESCRIPTION
## Summary
- enforce strict gap from forbidden zones in layout solver
- support alignment checks in layout validator

## Testing
- `python -m py_compile layout_solver.py validate_ifc.py`

------
https://chatgpt.com/codex/tasks/task_e_6870322418bc8323a09f87ca24d71b49